### PR TITLE
Common CRUD definition

### DIFF
--- a/resource/HypermediaRequest.py
+++ b/resource/HypermediaRequest.py
@@ -1,5 +1,5 @@
 """
-HypermediaRequest is the base class for a dictionary driven interface
+HypermediaRequest is the base class for the Common CRUD CCML client, a dictionary driven interface
 to http and CoAP requesters and response handlers to be used by clients and server request processors
 
 Requests and their associated responses are exposed in a dictionary interface for processing by proxies and resources

--- a/terms.py
+++ b/terms.py
@@ -1,4 +1,4 @@
-
+""" CCML Commom CRUD Interface mapping """
 """terms for methods"""
 get = "GET"
 put = "PUT"


### PR DESCRIPTION
CCML is Common CRUD, to standardize REST API commands, responses, and
options between HTTP and CoAP, and also to enable REST over MQTT with
the addition of a transaction header
